### PR TITLE
Removed upper limit on react-cli version.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,7 +145,7 @@ function createRNProjectSync(projectName, cmd) {
   ).start();
   const rnProjectCreationResponse = spawnSync(
     constantObjects.rnPackageName,
-    ["init", projectName, "--version", constantObjects.stableRNVersion],
+    ["init", projectName ],
     { stdio: "inherit", shell: true }
   );
   spinner.succeed(


### PR DESCRIPTION
Current recommended version of react-cli is > v0.61 

Removing this limit will also allow live reloading to work as expected.